### PR TITLE
Bugfix: Critical typo in Expexp.instantiate

### DIFF
--- a/ints/expexp.ml
+++ b/ints/expexp.ml
@@ -388,7 +388,7 @@ and instantiateAux e map =
   match e with
     | Pol p -> instantiateAuxPol p map
     | Sum (e1, e2) -> Sum (instantiate e1 map, instantiate e2 map)
-    | Mul (e1, e2) -> Mul (instantiate e1 map, instantiate e1 map)
+    | Mul (e1, e2) -> Mul (instantiate e1 map, instantiate e2 map)
     | Exp (e1, e2) -> Exp (instantiate e1 map, instantiate e2 map)
 and instantiateAuxPol (monos, c) map =
   let tmp = (List.map (instantiateAuxMono map) monos) @ [fromConstant c] in


### PR DESCRIPTION
This appears to be a typo that results in incorrect behaviour and has probably gone unnoticed up to now because `Expexp.instantiate` is used in just a few places and the bug occurs with nonpolynomial expressions only. I noticed the bug while experimenting with allowing exponential (instead of only polynomial) rule costs in the input file.
