### PR TITLE
Comrule.compare bugfix: also compare lower/upperBound, fixes #6

### DIFF
--- a/terms/comrule.ml
+++ b/terms/comrule.ml
@@ -98,7 +98,15 @@ let compare r1 r2 =
       if rhsComp <> 0 then
         rhsComp
       else
-        Pc.compare r1.cond r2.cond
+        let cComp = Pc.compare r1.cond r2.cond in
+        if cComp <> 0 then
+          cComp
+        else
+          let uComp = Poly.compare r1.upperBound r2.upperBound in
+          if uComp <> 0 then
+            uComp
+          else
+            Poly.compare r1.lowerBound r2.lowerBound
 
 (* Create a string for a rule *)
 let toDotString r =


### PR DESCRIPTION
This fixes issue #6, as now the two rules

```
  f(a) -{0,0}> g(a)
  f(a) -{b,b}> g(a)
```

will no longer be treated equal, so `RuleMap` in `CTRSObl` will work correctly.

---

I am not fully sure if this breaks something. A quick search showed that `RuleT.compare` is referenced at least from:
- `utils/rvgraph.ml`, line 37
- `utils/globalSizeComplexity.ml`, line 32
- `terms/ctrs.ml`, line 41 (this fixes `RuleMap`)

Maybe someone with more knowledge of the code can quickly look over these places, if the more precise comparison might break anything?

Please note that this compares the upper as well as the lower bound.
